### PR TITLE
Update Gib States, Spawn Menus to use sliders, mark safe skull column as NOTARGET

### DIFF
--- a/LANGUAGE
+++ b/LANGUAGE
@@ -24,6 +24,12 @@ MENU_ENEMYSPAWNRATE                     = "Enemy Spawn Rate: ";
 MENU_PERSISTENCY                        = "Persistent Spawns: ";
 MENU_ENEMYPERSISTENCY                   = "Persistent Enemy Spawns: ";
 
+// Menu Option Values
+MENU_ENABLED                            = "Enabled";
+MENU_DISABLED                           = "Disabled";
+MENU_REPLACEALL                         = "Replace All";
+MENU_WITHALL                            = "With All";
+
 // Menu Command Text
 MENU_RESETENEMY                         = "Reset Enemy Options";
 MENU_RESETPERSISTENCY                   = "Reset Persistence Options";

--- a/MENUDEF
+++ b/MENUDEF
@@ -1,19 +1,3 @@
-// Spawn Bias (for enemies that do replace their replacees)
-OptionValue "SpawnBias" {
-	-1,    "Disabled"
-	 0,    "Replace All"
-	 2,    "1 in 3"
-	 4,    "1 in 5"
-	 9,    "1 in 10"
-	 14,   "1 in 15"
-	 19,   "1 in 20"
-	 24,   "1 in 25"
-	 49,   "1 in 50"
-	 99,   "1 in 100"
-	 149,  "1 in 150"
-	 199,  "1 in 200"
-}
-
 OptionMenu "HDDiabloniumMenu"
 {
     StaticText "$MENU_ENEMIES_TITLE", "Fire"
@@ -52,10 +36,10 @@ OptionMenu "babydevilerSpawning" {
 
 	StaticText "$MENU_SPAWNOPTIONS", "Fire"
     StaticText "$MENU_BABYDEVILER_BABUIN_SPAWNTEXT", "White"
-	Option "$MENU_ENEMYSPAWNRATE", "babydeviler_babuin_spawn_bias", "SpawnBias"
+	ScaleSlider "$MENU_ENEMYSPAWNRATE", "babydeviler_babuin_spawn_bias", -1, 999, 1, "$MENU_REPLACEALL", "$MENU_DISABLED"
 	SafeCommand "$MENU_RESETENEMY", "resetcvar babydeviler_babuin_spawn_bias"
     StaticText "$MENU_BABYDEVILER_SPECTRE_SPAWNTEXT", "White"
-	Option "$MENU_ENEMYSPAWNRATE", "babydeviler_spectre_spawn_bias", "SpawnBias"
+	ScaleSlider "$MENU_ENEMYSPAWNRATE", "babydeviler_spectre_spawn_bias", -1, 999, 1, "$MENU_REPLACEALL", "$MENU_DISABLED"
 	SafeCommand "$MENU_RESETENEMY", "resetcvar babydeviler_spectre_spawn_bias"
  	StaticText ""
 
@@ -80,7 +64,7 @@ OptionMenu "teendevilerSpawning" {
 
 	StaticText "$MENU_SPAWNOPTIONS", "Fire"
     StaticText "$MENU_TEENDEVILER_IMP_SPAWNTEXT", "White"
-	Option "$MENU_ENEMYSPAWNRATE", "teendeviler_imp_spawn_bias", "SpawnBias"
+	ScaleSlider "$MENU_ENEMYSPAWNRATE", "teendeviler_imp_spawn_bias", -1, 999, 1, "$MENU_REPLACEALL", "$MENU_DISABLED"
 	SafeCommand "$MENU_RESETENEMY", "resetcvar teendeviler_imp_spawn_bias"
  	StaticText ""
 
@@ -105,7 +89,7 @@ OptionMenu "adultdevilerSpawning" {
 
 	StaticText "$MENU_SPAWNOPTIONS", "Fire"
     StaticText "$MENU_ADULTDEVILER_HELLKNIGHT_SPAWNTEXT", "White"
-	Option "$MENU_ENEMYSPAWNRATE", "adultdeviler_hellknight_spawn_bias", "SpawnBias"
+	ScaleSlider "$MENU_ENEMYSPAWNRATE", "adultdeviler_hellknight_spawn_bias", -1, 999, 1, "$MENU_REPLACEALL", "$MENU_DISABLED"
 	SafeCommand "$MENU_RESETENEMY", "resetcvar adultdeviler_hellknight_spawn_bias"
  	StaticText ""
 
@@ -130,13 +114,13 @@ OptionMenu "wretchedghoulSpawning" {
 
 	StaticText "$MENU_SPAWNOPTIONS", "Fire"
     StaticText "$MENU_WRETCHEDGHOUL_LOSTSOUL_SPAWNTEXT", "White"
-	Option "$MENU_ENEMYSPAWNRATE", "wretchedghoul_lostsoul_spawn_bias", "SpawnBias"
+	ScaleSlider "$MENU_ENEMYSPAWNRATE", "wretchedghoul_lostsoul_spawn_bias", -1, 999, 1, "$MENU_REPLACEALL", "$MENU_DISABLED"
 	SafeCommand "$MENU_RESETENEMY", "resetcvar wretchedghoul_lostsoul_spawn_bias"
     StaticText "$MENU_WRETCHEDGHOUL_BABUIN_SPAWNTEXT", "White"
-	Option "$MENU_ENEMYSPAWNRATE", "wretchedghoul_babuin_spawn_bias", "SpawnBias"
+	ScaleSlider "$MENU_ENEMYSPAWNRATE", "wretchedghoul_babuin_spawn_bias", -1, 999, 1, "$MENU_REPLACEALL", "$MENU_DISABLED"
 	SafeCommand "$MENU_RESETENEMY", "resetcvar wretchedghoul_babuin_spawn_bias"
     StaticText "$MENU_WRETCHEDGHOUL_SPECTRE_SPAWNTEXT", "White"
-	Option "$MENU_ENEMYSPAWNRATE", "wretchedghoul_spectre_spawn_bias", "SpawnBias"
+	ScaleSlider "$MENU_ENEMYSPAWNRATE", "wretchedghoul_spectre_spawn_bias", -1, 999, 1, "$MENU_REPLACEALL", "$MENU_DISABLED"
 	SafeCommand "$MENU_RESETENEMY", "resetcvar wretchedghoul_spectre_spawn_bias"
  	StaticText ""
 

--- a/zscript/Wretched.zs
+++ b/zscript/Wretched.zs
@@ -462,7 +462,7 @@ Class WretchedGhoul : HDMobBase
 				}
 				GHST F 2; 
 				#### A 0 A_Jump(256,"see");
-			xDeath:
+			gib:
 				POSS I 0 
 				{
 					A_SpawnItemEx("BFGNecroShard",flags:SXF_TRANSFERPOINTERS|SXF_SETMASTER,240);

--- a/zscript/possessedskullcombo.zs
+++ b/zscript/possessedskullcombo.zs
@@ -16,6 +16,7 @@ Class HarmlessSkulCol : HDActor
 	Radius 16;
 	Height 40;
 	+solid
+	+notarget
 	}
 	states
 	{


### PR DESCRIPTION
The gib states are for the latest changes to HDest main, the sliders are for an update prettyFist suggested a while back that I never got around to making a separate PR for.

I also noticed the Skull Column isn't marked to be ignored, so the MobAI keeps wanting to shoot at it.  Marking it as a NOTARGET should deny them targeting it.

If you'd prefer to split these up or you don't want some of the changes, let me know!